### PR TITLE
Longer inter-character timeout for connect

### DIFF
--- a/GPRS_Shield_Arduino.cpp
+++ b/GPRS_Shield_Arduino.cpp
@@ -495,7 +495,7 @@ void GPRS::disconnect()
     sim900_send_cmd("AT+CIPSHUT\r\n");
 }
 
-bool GPRS::connect(Protocol ptl,const char * host, int port, int timeout)
+bool GPRS::connect(Protocol ptl,const char * host, int port, int timeout, int chartimeout)
 {
     //char cmd[64];
 	char num[4];
@@ -525,7 +525,7 @@ bool GPRS::connect(Protocol ptl,const char * host, int port, int timeout)
     
 
     //sim900_send_cmd(cmd);
-    sim900_read_buffer(resp,96,timeout, timeout * 1000);
+    sim900_read_buffer(resp, 96, timeout, chartimeout);
 //Serial.print("Connect resp: "); Serial.println(resp);    
     if(NULL != strstr(resp,"CONNECT")) { //ALREADY CONNECT or CONNECT OK
         return true;
@@ -534,7 +534,7 @@ bool GPRS::connect(Protocol ptl,const char * host, int port, int timeout)
 }
 
 //Overload with F() macro to SAVE memory
-bool GPRS::connect(Protocol ptl,const __FlashStringHelper *host, const __FlashStringHelper *port, int timeout)
+bool GPRS::connect(Protocol ptl,const __FlashStringHelper *host, const __FlashStringHelper *port, int timeout, int chartimeout)
 {
     //char cmd[64];
     char resp[96];
@@ -552,7 +552,7 @@ bool GPRS::connect(Protocol ptl,const __FlashStringHelper *host, const __FlashSt
     sim900_send_cmd(port);
     sim900_send_cmd(F("\r\n"));
 //Serial.print("Connect: "); Serial.println(cmd);
-    sim900_read_buffer(resp, 96, timeout, timeout * 1000);
+    sim900_read_buffer(resp, 96, timeout, chartimeout);
 //Serial.print("Connect resp: "); Serial.println(resp);    
     if(NULL != strstr(resp,"CONNECT")) { //ALREADY CONNECT or CONNECT OK
         return true;

--- a/GPRS_Shield_Arduino.cpp
+++ b/GPRS_Shield_Arduino.cpp
@@ -525,7 +525,7 @@ bool GPRS::connect(Protocol ptl,const char * host, int port, int timeout)
     
 
     //sim900_send_cmd(cmd);
-    sim900_read_buffer(resp,96,timeout);
+    sim900_read_buffer(resp,96,timeout, timeout * 1000);
 //Serial.print("Connect resp: "); Serial.println(resp);    
     if(NULL != strstr(resp,"CONNECT")) { //ALREADY CONNECT or CONNECT OK
         return true;
@@ -552,7 +552,7 @@ bool GPRS::connect(Protocol ptl,const __FlashStringHelper *host, const __FlashSt
     sim900_send_cmd(port);
     sim900_send_cmd(F("\r\n"));
 //Serial.print("Connect: "); Serial.println(cmd);
-    sim900_read_buffer(resp, 96, timeout);
+    sim900_read_buffer(resp, 96, timeout, timeout * 1000);
 //Serial.print("Connect resp: "); Serial.println(resp);    
     if(NULL != strstr(resp,"CONNECT")) { //ALREADY CONNECT or CONNECT OK
         return true;

--- a/GPRS_Shield_Arduino.h
+++ b/GPRS_Shield_Arduino.h
@@ -193,10 +193,11 @@ public:
      *  @param host host (can be either an ip address or a name. If a name is provided, a dns request will be established)
      *  @param port port
      *  @param timeout wait seconds till connected
+     *  @param chartimeout wait milliseconds between characters from GPRS module
      *  @returns true if successful
      */
-    bool connect(Protocol ptl, const char * host, int port, int timeout = 2 * DEFAULT_TIMEOUT);
-	bool connect(Protocol ptl, const __FlashStringHelper *host, const __FlashStringHelper *port, int timeout = 2 * DEFAULT_TIMEOUT);
+    bool connect(Protocol ptl, const char * host, int port, int timeout = 2 * DEFAULT_TIMEOUT, int chartimeout = 2 * DEFAULT_INTERCHAR_TIMEOUT);
+	bool connect(Protocol ptl, const __FlashStringHelper *host, const __FlashStringHelper *port, int timeout = 2 * DEFAULT_TIMEOUT, int chartimeout = 2 * DEFAULT_INTERCHAR_TIMEOUT);
 
     /** Check if a tcp link is active
      *  @returns true if successful


### PR DESCRIPTION
`GPRS::connect()` often failed for me. I found that the SIM900 responds to the `AT+CIPSTART` command immediately with `OK`, but then takes a couple of seconds to follow up with `CONNECT OK`. This delay was more than the default inter-character timeout, so `sim900_read_buffer()` would return before it read the `CONNECT OK`, and `GPRS::connect()` would return `false`.

Making the inter-character timeout the same as the other timeout parameter fixes this for me.