### PR TITLE
Don't dereference null pointers for apn, userName, password

### DIFF
--- a/GPRS_Shield_Arduino.cpp
+++ b/GPRS_Shield_Arduino.cpp
@@ -448,11 +448,17 @@ bool GPRS::join(const __FlashStringHelper *apn, const __FlashStringHelper *userN
     //snprintf(cmd,sizeof(cmd),"AT+CSTT=\"%s\",\"%s\",\"%s\"\r\n",_apn,_userName,_passWord);
     //sim900_check_with_cmd(cmd, "OK\r\n", DEFAULT_TIMEOUT,CMD);
     sim900_send_cmd("AT+CSTT=\"");
-    sim900_send_cmd(apn);
+    if (apn) {
+      sim900_send_cmd(apn);
+    }
     sim900_send_cmd("\",\"");
-    sim900_send_cmd(userName);
+    if (userName) {
+      sim900_send_cmd(userName);
+    }
     sim900_send_cmd("\",\"");
-    sim900_send_cmd(passWord);
+    if (passWord) {
+      sim900_send_cmd(passWord);
+    }
     sim900_check_with_cmd("\"\r\n", "OK\r\n", CMD);
     
 


### PR DESCRIPTION
Omitting `apn`, `userName`, `passWord` arguments from call to `GPRS::join` resulted in errors due to dereferencing the default null values (long string of garbage data was sent to device). Simply test `apn`, `userName`, `passWord` against null before sending them.