### PR TITLE
Added support for HardwareSerial

### DIFF
--- a/GPRS_Shield_Arduino.cpp
+++ b/GPRS_Shield_Arduino.cpp
@@ -34,25 +34,35 @@
 
 GPRS* GPRS::inst;
 
-GPRS::GPRS(uint8_t tx, uint8_t rx, uint32_t baudRate):gprsSerial(tx,rx)
+GPRS::GPRS(HardwareSerial *pHWSerial, uint32_t baudRate): gprsSerial(60, 61)
+{
+	inst = this;
+	pHWSerial->begin(baudRate);
+	sim900_init(pHWSerial);
+}
+
+GPRS::GPRS(uint8_t tx, uint8_t rx, uint32_t baudRate): gprsSerial(tx, rx)
 {
     inst = this;
-    sim900_init(&gprsSerial, baudRate);
+	gprsSerial.begin(baudRate);
+    sim900_init(&gprsSerial);
 }
 
 bool GPRS::init(void)
 {
+	Serial.println("11111");
     if(!sim900_check_with_cmd(F("AT\r\n"),"OK\r\n",CMD)){
 		return false;
     }
-    
+	Serial.println("22222");
     if(!sim900_check_with_cmd(F("AT+CFUN=1\r\n"),"OK\r\n",CMD)){
         return false;
     }
-    
+	Serial.println("33333");
     if(!checkSIMStatus()) {
 		return false;
     }
+	Serial.println("44444");
 
     return true;
 }
@@ -129,7 +139,7 @@ bool GPRS::isNetworkRegistered(void)
     return true;
 }
 
-bool GPRS::sendSMS(char *number, char *data)
+bool GPRS::sendSMS(const char *number, const char *data)
 {    
     //char cmd[32];
     if(!sim900_check_with_cmd(F("AT+CMGF=1\r\n"), "OK\r\n", CMD)) { // Set message mode to ASCII

--- a/GPRS_Shield_Arduino.h
+++ b/GPRS_Shield_Arduino.h
@@ -51,7 +51,8 @@ public:
      *  @param number default phone number during mobile communication
      */
 	 
-    GPRS(uint8_t tx, uint8_t rx, uint32_t baudRate = 9600 ); 
+    GPRS(HardwareSerial *pHWSerial, uint32_t baudRate = 9600 );
+	GPRS(uint8_t tx,  uint8_t rx, uint32_t baudRate = 9600 ); 
     
     /** get instance of GPRS class
      */
@@ -101,7 +102,7 @@ public:
      *      false on success
      *      true on error
      */
-    bool sendSMS(char* number, char* data);
+    bool sendSMS(const char* number, const char* data);
 
     /** Check if there is any UNREAD SMS: this function DOESN'T change the UNREAD status of the SMS
      *  @returns

--- a/sim900.cpp
+++ b/sim900.cpp
@@ -31,12 +31,12 @@
 
 #include "sim900.h"
 
-SoftwareSerial *serialSIM900 = NULL;
 
-void  sim900_init(void * uart_device, uint32_t baud)
+Stream *serialSIM900 = NULL;
+
+void  sim900_init(Stream* uart_device)
 {
-    serialSIM900 = (SoftwareSerial*)uart_device;
-	  serialSIM900->begin(baud);
+    serialSIM900 = uart_device;
 }
 
 int sim900_check_readable()

--- a/sim900.h
+++ b/sim900.h
@@ -47,7 +47,7 @@ enum DataType {
     DATA    = 1,
 };
 
-void  sim900_init(void * uart_device, uint32_t baud);
+void  sim900_init(Stream* uart_device);
 int   sim900_check_readable();
 int   sim900_wait_readable(int wait_time);
 void  sim900_flush_serial();


### PR DESCRIPTION
GPRS::GPRS(HardwareSerial *pHWSerial, uint32_t baudRate): gprsSerial(60, 61)
{
	inst = this;
	pHWSerial->begin(baudRate);
	sim900_init(pHWSerial);
}

GPRS::GPRS(uint8_t tx, uint8_t rx, uint32_t baudRate): gprsSerial(tx, rx)
{
    inst = this;
	gprsSerial.begin(baudRate);
    sim900_init(&gprsSerial);
}

Stream *serialSIM900 = NULL;

void  sim900_init(Stream* uart_device)
{
    serialSIM900 = uart_device;
}
Are these functions really needed? 
Not used by any example sketches and no equivalent functions available in class HardwareSerial.
void GPRS::listen(void)
{
	gprsSerial.listen();
}

bool GPRS::isListening(void)
{
	return gprsSerial.isListening();
}