### PR TITLE
`GPRS::isCallActive` fix

### DIFF
--- a/GPRS_Shield_Arduino.cpp
+++ b/GPRS_Shield_Arduino.cpp
@@ -430,11 +430,12 @@ bool GPRS::isCallActive(char *number)
       OK
     */
 
-    sim900_clean_buffer(gprsBuffer,29);
-    sim900_read_buffer(gprsBuffer,27);
     //HACERR cuando haga lo de esperar a OK no me haría falta esto
     //We are going to flush serial data until OK is recieved
-    sim900_wait_for_resp("OK\r\n", CMD);    
+    sim900_wait_for_resp("OK\r\n", CMD);
+    
+    sim900_clean_buffer(gprsBuffer,29);
+    sim900_read_buffer(gprsBuffer,27);
     //Serial.print("Buffer isCallActive 1: ");Serial.println(gprsBuffer);
     if(NULL != ( s = strstr(gprsBuffer,"+CPAS:"))) {
       s = s + 7;


### PR DESCRIPTION
* Currently: `GPRS::isCallActive` sends `AT+CPAS\r\n`, reads back the response and *then* waits for `OK\r\n`. So, even when a call is in progress, it can miss the `+CPAS` response and return `false` by default.

* This PR switches the wait and read commands.

* Fixes #10 for me.