### PR TITLE
force disable sms notification, to allow sms read

### DIFF
--- a/GPRS_Shield_Arduino.cpp
+++ b/GPRS_Shield_Arduino.cpp
@@ -64,6 +64,12 @@ bool GPRS::init(void)
     }
 	Serial.println("44444");
 
+    // Disable SMS notifications
+    if(!sim900_check_with_cmd(F("AT+CNMI=0,0,0,0,0\r\n"),"OK\r\n",CMD)){
+        return false;
+    }
+	Serial.println("55555");
+
     return true;
 }
 


### PR DESCRIPTION
When using SIM900 module from factory, SMSread example will not work because module is receiving sms event callback through serial port.

Force disabling sms notification, will solve the problem.