### PR TITLE
getVcc, low power mode, SMS text mode

### DIFF
--- a/GPRS_Shield_Arduino.cpp
+++ b/GPRS_Shield_Arduino.cpp
@@ -649,7 +649,7 @@ bool GPRS::wake(void)
 	//Second delay almost 100 ms
 	delay(200);
 	sim900_flush_serial();
-	//Third, send the second AT command to check that it is alive HACERR posible while durante un tiempo reintentando los ATs
+	//Third, send the second AT command to check that it is alive
     timerStart = millis();
     while(!ok && ((unsigned long) (millis() - timerStart) < 3000UL) ) {  //Until 3 seconds maximum
 		ok = sim900_check_with_cmd(F("AT\r\n"),"OK",CMD);

--- a/GPRS_Shield_Arduino.cpp
+++ b/GPRS_Shield_Arduino.cpp
@@ -34,46 +34,38 @@
 
 GPRS* GPRS::inst;
 
-GPRS::GPRS(HardwareSerial *pHWSerial, uint32_t baudRate): gprsSerial(60, 61)
-{
-	inst = this;
-	pHWSerial->begin(baudRate);
-	sim900_init(pHWSerial);
-}
-
-GPRS::GPRS(uint8_t tx, uint8_t rx, uint32_t baudRate): gprsSerial(tx, rx)
+GPRS::GPRS(uint8_t tx, uint8_t rx, uint32_t baudRate):gprsSerial(tx,rx)
 {
     inst = this;
-	gprsSerial.begin(baudRate);
-    sim900_init(&gprsSerial);
+    sim900_init(&gprsSerial, baudRate);
 }
 
 bool GPRS::init(void)
 {
-	Serial.println("11111");
     if(!sim900_check_with_cmd(F("AT\r\n"),"OK\r\n",CMD)){
 		return false;
     }
-	Serial.println("22222");
+    
     if(!sim900_check_with_cmd(F("AT+CFUN=1\r\n"),"OK\r\n",CMD)){
         return false;
     }
-	Serial.println("33333");
+	
+	//180822 Set SMS to text mode
+	if(!sim900_check_with_cmd(F("AT+CMGF=1\r\n"), "OK\r\n", CMD)) { // Set message mode to ASCII
+        return false;
+    }
+    //delay(500);	It is not necessary, as we have time before next command
+    
     if(!checkSIMStatus()) {
 		return false;
     }
-	Serial.println("44444");
-
     return true;
 }
 
-bool GPRS::checkPowerUp(uint8_t pin)
+bool GPRS::checkPowerUp(void)
 {
-  if(!sim900_check_with_cmd(F("AT\r\n"),"OK\r\n",CMD))
-  {
-      powerUpDown(pin);
-  }
-
+  return sim900_check_with_cmd(F("AT\r\n"),"OK\r\n",CMD);
+  //We dont need here any pin, as this library has to work also with SIM800L 
 }
 
 void GPRS::powerUpDown(uint8_t pin)
@@ -90,10 +82,10 @@ void GPRS::powerUpDown(uint8_t pin)
 void GPRS::powerReset(uint8_t pin)
 {
   // reset for SIM800L board.
-  // RST pin has to be OUTPUT, HIGH
-  digitalWrite(pin,LOW);
-  delay(1000);
+  // RST pin has to be OUTPUT, LOW and with a NPN transistor 
   digitalWrite(pin,HIGH);
+  delay(1000);
+  digitalWrite(pin,LOW);
   delay(3000);  
 }
   
@@ -126,10 +118,10 @@ bool GPRS::isNetworkRegistered(void)
     while(count < 3) {
         sim900_send_cmd(F("AT+CREG?\r\n"));
         sim900_read_buffer(gprsBuffer,32,DEFAULT_TIMEOUT);
-	//Check if home network (0,1) ir roaming (0,5) is enabled
-	if( (NULL != strstr(gprsBuffer,"+CREG: 0,1")) || (NULL != strstr(gprsBuffer,"+CREG: 0,5")) ) {
-		break;
-	}
+		//Check if home network (0,1) ir roaming (0,5) is enabled
+		if( (NULL != strstr(gprsBuffer,"+CREG: 0,1")) || (NULL != strstr(gprsBuffer,"+CREG: 0,5")) ) {
+			break;
+		}
         count++;
         delay(300);
     }
@@ -139,13 +131,16 @@ bool GPRS::isNetworkRegistered(void)
     return true;
 }
 
+
 bool GPRS::sendSMS(const char *number, const char *data)
-{    
-    //char cmd[32];
-    if(!sim900_check_with_cmd(F("AT+CMGF=1\r\n"), "OK\r\n", CMD)) { // Set message mode to ASCII
-        return false;
-    }
-    delay(500);
+{
+
+	//180822 In the init function
+	//if(!sim900_check_with_cmd(F("AT+CMGF=1\r\n"), "OK\r\n", CMD)) { // Set message mode to ASCII
+    //    return false;
+    //}
+    //delay(500);
+	
 	sim900_flush_serial();
 	sim900_send_cmd(F("AT+CMGS=\""));
 	sim900_send_cmd(number);
@@ -157,8 +152,9 @@ bool GPRS::sendSMS(const char *number, const char *data)
     }
     delay(1000);
     sim900_send_cmd(data);
+    delay(500);
     sim900_send_End_Mark();
-    return sim900_wait_for_resp("OK\r\n", CMD, 5, 5000);
+    return sim900_wait_for_resp("OK\r\n", CMD);
 }
 
 char GPRS::isSMSunread()
@@ -246,8 +242,12 @@ bool GPRS::readSMS(int messageIndex, char *message, int length, char *phone, cha
 	char num[4];
     char *p,*p2,*s;
     
-    sim900_check_with_cmd(F("AT+CMGF=1\r\n"),"OK\r\n",CMD);
-    delay(1000);
+	//180822 In the init function
+	//if(!sim900_check_with_cmd(F("AT+CMGF=1\r\n"), "OK\r\n", CMD)) { // Set message mode to ASCII
+    //    return false;
+    //}
+    //delay(1000);	
+
 	//sprintf(cmd,"AT+CMGR=%d\r\n",messageIndex);
     //sim900_send_cmd(cmd);
 	sim900_send_cmd(F("AT+CMGR="));
@@ -295,7 +295,7 @@ bool GPRS::readSMS(int messageIndex, char *message, int length, char *phone, cha
     return false;    
 }
 
-bool GPRS::readSMS(int messageIndex, char *message,int length)
+bool GPRS::readSMS(int messageIndex, char *message, int length)
 {
     int i = 0;
     char gprsBuffer[100];
@@ -303,8 +303,12 @@ bool GPRS::readSMS(int messageIndex, char *message,int length)
 	char num[4];
     char *p,*s;
     
-    sim900_check_with_cmd(F("AT+CMGF=1\r\n"),"OK\r\n",CMD);
-    delay(1000);
+	//180822 In the init function
+	//if(!sim900_check_with_cmd(F("AT+CMGF=1\r\n"), "OK\r\n", CMD)) { // Set message mode to ASCII
+    //    return false;
+    //}
+    //delay(1000);	
+	
 	sim900_send_cmd(F("AT+CMGR="));
 	itoa(messageIndex, num, 10);
 	sim900_send_cmd(num);
@@ -431,17 +435,18 @@ bool GPRS::isCallActive(char *number)
     */
 
     sim900_clean_buffer(gprsBuffer,64);
-    sim900_read_string_until(gprsBuffer,64, "OK", 2);
-    //HACERR cuando haga lo de esperar a OK no me haría falta esto
-    //We are going to flush serial data until OK is recieved
+    sim900_read_string_until(gprsBuffer,64, "OK", 2); 
+
+
+
     if(NULL != ( s = strstr(gprsBuffer,"+CPAS:"))) {
       s = s + 7;
       if (*s != '0') {
          //There is something "running" (but number 2 that is unknow)
          if (*s != '2') {
-           //3 or 4, let's go to check for the number            
-            delay(5);
-            sim900_send_cmd(F("AT+CLCC\r\n"));
+           //3 or 4, let's go to check for the number
+		   delay(5);		 
+           sim900_send_cmd(F("AT+CLCC\r\n"));
            /*
            AT+CLCC --> 9
            
@@ -456,7 +461,7 @@ bool GPRS::isCallActive(char *number)
 
            sim900_clean_buffer(gprsBuffer,64);
            sim900_read_string_until(gprsBuffer,64, "OK", 2);
-			     //Serial.print("Buffer isCallActive 2: ");Serial.println(gprsBuffer);
+			
            if(NULL != ( s = strstr(gprsBuffer,"+CLCC:"))) {
              //There is at least one CALL ACTIVE, get number
              s = strstr((char *)(s),"\"");
@@ -469,8 +474,10 @@ bool GPRS::isCallActive(char *number)
                 }
                 number[i] = '\0';            
              }
-           }
-           return true;
+           } else {
+			   return false;
+		   }
+		   return true;
          }
       }        
     } 
@@ -517,6 +524,40 @@ bool GPRS::getDateTime(char *buffer)
     }  
     return false;
 }
+
+bool GPRS::getVcc(char *buffer)
+{
+	//AT+CBC            --> 6 + CR
+	//+CBC: 0,100,4241	--> CRLF + 16 + CRLF
+	//
+	//OK			    --> CRLF + 2 + CRLF
+	
+    byte i = 0;
+    char gprsBuffer[50];
+    char *p,*s;
+	sim900_flush_serial();
+    sim900_send_cmd(F("AT+CBC\r"));
+    sim900_clean_buffer(gprsBuffer,50);
+    sim900_read_buffer(gprsBuffer,50,DEFAULT_TIMEOUT);
+    if(NULL != ( s = strstr(gprsBuffer,"+CBC:"))) {
+        s = strstr((char *)(s),",");
+        s = s + 1; 
+        s = strstr((char *)(s), ","); 
+        s = s + 1; //We are in the first Vcc character
+        p = s + 4; //p is last character
+        if (NULL != s) {
+            i = 0;
+            while (s < p) {
+              buffer[i++] = *(s++);
+            }
+            buffer[i] = '\0';            
+        }
+        return true;
+    }  
+    return false;
+}
+
+
 
 bool GPRS::getSignalStrength(int *buffer)
 {
@@ -594,6 +635,34 @@ bool GPRS::cancelUSSDSession(void)
     return sim900_check_with_cmd(F("AT+CUSD=2\r\n"),"OK\r\n",CMD);
 }
 
+bool GPRS::sleep(void)
+{
+    return sim900_check_with_cmd(F("AT+CSCLK=2\r\n"),"OK\r\n",CMD);
+}
+
+bool GPRS::wake(void)
+{
+    unsigned long timerStart;
+	bool ok = false;
+	//First, send AT dummy command to wake up
+	sim900_send_cmd(F("AT\r\n"));
+	//Second delay almost 100 ms
+	delay(200);
+	sim900_flush_serial();
+	//Third, send the second AT command to check that it is alive HACERR posible while durante un tiempo reintentando los ATs
+    timerStart = millis();
+    while(!ok && ((unsigned long) (millis() - timerStart) < 3000UL) ) {  //Until 3 seconds maximum
+		ok = sim900_check_with_cmd(F("AT\r\n"),"OK",CMD);
+		delay(300);
+    }
+	if (ok) {
+		//Four, exit sleep mode
+		return sim900_check_with_cmd(F("AT+CSCLK=0\r\n"),"OK",CMD);
+	} else {
+		return false;
+	}
+}
+
 //Here is where we ask for APN configuration, with F() so we can save MEMORY
 bool GPRS::join(const __FlashStringHelper *apn, const __FlashStringHelper *userName, const __FlashStringHelper *passWord)
 {
@@ -606,8 +675,10 @@ bool GPRS::join(const __FlashStringHelper *apn, const __FlashStringHelper *userN
     //set APN. OLD VERSION
     //snprintf(cmd,sizeof(cmd),"AT+CSTT=\"%s\",\"%s\",\"%s\"\r\n",_apn,_userName,_passWord);
     //sim900_check_with_cmd(cmd, "OK\r\n", DEFAULT_TIMEOUT,CMD);
-    
-    sim900_check_with_cmd("AT+CIPSHUT\r\n", "SHUT OK\r\n", CMD, 2000, 1000);  /**Reset the IP session if any**/
+
+    //It is the user who need to call gprs.close and gprs.disconnect
+	//sim900_check_with_cmd("AT+CIPSHUT\r\n", "SHUT OK\r\n", CMD, 2000, 1000);  /**Reset the IP session if any**/	
+	
     sim900_send_cmd(F("AT+CSTT=\""));
     if (apn) {
       sim900_send_cmd(apn);
@@ -707,9 +778,7 @@ bool GPRS::connect(Protocol ptl,const char * host, int port, int timeout, int ch
 //Overload with F() macro to SAVE memory
 bool GPRS::connect(Protocol ptl,const __FlashStringHelper *host, const __FlashStringHelper *port, int timeout, int chartimeout)
 {
-
     char resp[96];
-
 
     if(ptl == TCP) {
         sim900_send_cmd(F("AT+CIPSTART=\"TCP\",\""));   //%s\",%d\r\n",host, port);
@@ -809,7 +878,7 @@ boolean GPRS::send(const char * str)
 	sim900_send_End_Mark();
 	if(!sim900_wait_for_resp("SEND OK\r\n", DATA, DEFAULT_TIMEOUT * 10, DEFAULT_INTERCHAR_TIMEOUT * 10)) {
 		return false;
-	}        
+	}   
     return true;
 }
 
@@ -919,4 +988,4 @@ bool GPRS::getLocation(const __FlashStringHelper *apn, float *longitude, float *
 void GPRS::AT_Bypass()
 {
     sim900_AT_bypass();
-}
+}					  

--- a/GPRS_Shield_Arduino.h
+++ b/GPRS_Shield_Arduino.h
@@ -50,8 +50,6 @@ public:
     /** Create GPRS instance
      *  @param number default phone number during mobile communication
      */
-	 
-    GPRS(HardwareSerial *pHWSerial, uint32_t baudRate = 9600 );
 	GPRS(uint8_t tx,  uint8_t rx, uint32_t baudRate = 9600 ); 
     
     /** get instance of GPRS class
@@ -68,12 +66,11 @@ public:
 
    
     /** check if GPRS module is powered on or not
-     *  @param  pin pin 9 connected to JP jumper so we can power up and down through software
      *  @returns
      *      true on success
      *      false on error
      */
-    bool checkPowerUp(uint8_t pin = 9);
+    bool checkPowerUp(void);
 
     
     /** power Up GPRS module (JP has to be soldered)
@@ -89,7 +86,6 @@ public:
      *      
      */	
     void powerReset(uint8_t pin);
-
     /** Check network registration status
      *  @return true on success, false on fail
      */
@@ -200,7 +196,7 @@ public:
      * 	   If it doesn't work may be for two reasons:
      *	 	1. Your carrier doesn't give that information
      *		2. You have to configurate the SIM900 IC.
-         *			- First with SIM900_Serial_Debug example try this AT command: AT+CLTS?
+     *			- First with SIM900_Serial_Debug example try this AT command: AT+CLTS?
 	 *			- If response is 0, then it is disabled.
 	 *			- Enable it by: AT+CLTS=1
 	 *			- Now you have to save this config to EEPROM memory of SIM900 IC by: AT&W
@@ -210,6 +206,14 @@ public:
 	 *
      */
     bool getDateTime(char *buffer);
+	
+    /** get battery voltage from SIM900 in mV
+     *  @param
+     *  @returns
+     *      true on success
+     *      false on error
+     */
+    bool getVcc(char *buffer);
     
 	/** get Signal Strength from SIM900 (see AT command: AT+CSQ) as integer
 	*  @param
@@ -238,6 +242,23 @@ public:
      */
 	bool cancelUSSDSession(void);
 
+//////////////////////////////////////////////////////
+/// SLEEP
+////////////////////////////////////////////////////// 	
+    /** Enter sleep mode (AT+CSCLK=2)
+     *  @returns
+     *      true on success
+     *      false on error
+     */
+	bool sleep(void);	
+	
+    /** Exit sleep mode (AT+CSCLK=0)
+     *  @returns
+     *      true on success
+     *      false on error
+     */
+	bool wake(void);		
+	
 //////////////////////////////////////////////////////
 /// GPRS
 //////////////////////////////////////////////////////  
@@ -334,8 +355,7 @@ public:
     char* getIPAddress();
     unsigned long getIPnumber();	
     bool getLocation(const __FlashStringHelper *apn, float *longitude, float *latitude);
-    void AT_Bypass();
-    
+    void AT_Bypass();	
 private:
     bool checkSIMStatus(void);
     uint32_t str_to_ip(const char* str);

--- a/sim900.cpp
+++ b/sim900.cpp
@@ -32,11 +32,12 @@
 #include "sim900.h"
 
 
-Stream *serialSIM900 = NULL;
+SoftwareSerial *serialSIM900 = NULL;
 
-void  sim900_init(Stream* uart_device)
+void  sim900_init(void * uart_device, uint32_t baud)
 {
-    serialSIM900 = uart_device;
+    serialSIM900 = (SoftwareSerial*)uart_device;
+	serialSIM900->begin(baud);
 }
 
 int sim900_check_readable()
@@ -77,6 +78,7 @@ void sim900_read_buffer(char *buffer, int count, unsigned int timeout, unsigned 
             char c = serialSIM900->read();
             prevChar = millis();
             buffer[i++] = c;
+			DEBUG("-");DEBUG(c);
             if(i >= count)break;
         }
         if(i >= count)break;
@@ -122,6 +124,7 @@ uint16_t sim900_read_string_until(char *buffer, int count, char *pattern, unsign
     return (uint16_t)(i - 1);
 }
 
+
 void sim900_clean_buffer(char *buffer, int count)
 {
     for(int i=0; i < count; i++) {
@@ -129,15 +132,17 @@ void sim900_clean_buffer(char *buffer, int count)
     }
 }
 
-//HACERR quitar esta funcion ?
 void sim900_send_byte(uint8_t data)
 {
 	serialSIM900->write(data);
+	DEBUG((char)data);
 }
+	
 
 void sim900_send_char(const char c)
 {
 	serialSIM900->write(c);
+	DEBUG(c);
 }
 
 void sim900_send_cmd(const char* cmd)
@@ -183,7 +188,8 @@ boolean sim900_wait_for_resp(const char* resp, DataType type, unsigned int timeo
     while(1) {
         if(sim900_check_readable()) {
             char c = serialSIM900->read();
-            DEBUG(c);
+			DEBUG("-");
+			DEBUG(c);
             prevChar = millis();
             sum = (c==resp[sum]) ? sum+1 : 0;
             if(sum == len)break;
@@ -224,4 +230,4 @@ void sim900_AT_bypass()
   if(Serial.available()){   
     serialSIM900->write(Serial.read());
   }
-}
+}					   

--- a/sim900.h
+++ b/sim900.h
@@ -38,21 +38,19 @@
 #define DEFAULT_TIMEOUT     		 5   //seconds
 #define DEFAULT_INTERCHAR_TIMEOUT 3000   //miliseconds
 
-
 #define DEBUG(x) 
-//#define DEBUG(x) Serial.print(x)  
-
+//#define DEBUG(x) Serial.print(x)  				 
 enum DataType {
     CMD     = 0,
     DATA    = 1,
 };
 
-void  sim900_init(Stream* uart_device);
+void  sim900_init(void * uart_device, uint32_t baud);
 int   sim900_check_readable();
 int   sim900_wait_readable(int wait_time);
 void  sim900_flush_serial();
 void  sim900_read_buffer(char* buffer,int count,  unsigned int timeout = DEFAULT_TIMEOUT, unsigned int chartimeout = DEFAULT_INTERCHAR_TIMEOUT);
-uint16_t sim900_read_string_until(char *buffer, int count, char *pattern, unsigned int timeout = DEFAULT_TIMEOUT, unsigned int chartimeout = DEFAULT_INTERCHAR_TIMEOUT);
+uint16_t sim900_read_string_until(char *buffer, int count, char *pattern, unsigned int timeout = DEFAULT_TIMEOUT, unsigned int chartimeout = DEFAULT_INTERCHAR_TIMEOUT);																																										
 void  sim900_clean_buffer(char* buffer, int count);
 void  sim900_send_byte(uint8_t data);
 void  sim900_send_char(const char c);
@@ -64,6 +62,6 @@ void  sim900_send_End_Mark(void);
 boolean  sim900_wait_for_resp(const char* resp, DataType type, unsigned int timeout = DEFAULT_TIMEOUT, unsigned int chartimeout = DEFAULT_INTERCHAR_TIMEOUT);
 boolean  sim900_check_with_cmd(const char* cmd, const char *resp, DataType type, unsigned int timeout = DEFAULT_TIMEOUT, unsigned int chartimeout = DEFAULT_INTERCHAR_TIMEOUT*5);
 boolean  sim900_check_with_cmd(const __FlashStringHelper* cmd, const char *resp, DataType type, unsigned int timeout = DEFAULT_TIMEOUT, unsigned int chartimeout = DEFAULT_INTERCHAR_TIMEOUT);
-void sim900_AT_bypass();
+void sim900_AT_bypass();						
 
 #endif


### PR DESCRIPTION
get Vcc (milivolts) directly from SIM900 or SIM800L
sleep and wake functions for very low power consumption
checkPowerUp rewritten to work also with SIM800L or other boards
SMS text mode in init function to solve same issues
NOTE: I have deleted the hardware serial support as it is only for ATMEGA and only for special pins (special hardware serial port). We need to rewrite to work with other ATMEL IC's and ports.