### PR TITLE
added GPRS::send() method for progmem parameter, compiler warning fixes, is_connected bugfix

### DIFF
--- a/GPRS_Shield_Arduino.cpp
+++ b/GPRS_Shield_Arduino.cpp
@@ -965,6 +965,22 @@ int GPRS::send(const char * str, int len)
     return len;
 }
 
+boolean GPRS::send(const __FlashStringHelper* str)
+{
+    if(!sim900_check_with_cmd(F("AT+CIPSEND\r\n"),">",CMD)) {
+        return false;
+    }
+
+    sim900_send_cmd(str);
+    sim900_send_End_Mark();
+
+    if(!sim900_wait_for_resp("SEND OK\r\n", DATA, DEFAULT_TIMEOUT, DEFAULT_INTERCHAR_TIMEOUT)) {
+        return false;
+    }
+
+    return true;
+}
+
 boolean GPRS::send(const char * str)
 {
 	if(!sim900_check_with_cmd(F("AT+CIPSEND\r\n"),">",CMD)) {

--- a/GPRS_Shield_Arduino.cpp
+++ b/GPRS_Shield_Arduino.cpp
@@ -896,15 +896,19 @@ bool GPRS::connect(Protocol ptl,const __FlashStringHelper *host, const __FlashSt
 
 bool GPRS::is_connected(void)
 {
-    char resp[96];
+    // the largest possible value here is:
+    // OK\r\n
+    // STATE: SERVER LISTENING\r\n
+    // 40 byte should be fine
+    char resp[40];
     sim900_send_cmd(F("AT+CIPSTATUS\r\n"));
     sim900_read_buffer(resp,sizeof(resp),DEFAULT_TIMEOUT);
-    if(NULL != strstr(resp,"CONNECTED")) {
-        //+CIPSTATUS: 1,0,"TCP","216.52.233.120","80","CONNECTED"
+    if(NULL != strstr(resp,"STATE: CONNECT OK")) {
+        // OK\r\nSTATE: CONNECT OK
         return true;
     } else {
-        //+CIPSTATUS: 1,0,"TCP","216.52.233.120","80","CLOSED"
-        //+CIPSTATUS: 0,,"","","","INITIAL"
+        // e.g:
+        // OK\r\nSTATE: TCP CLOSED
         return false;
     }
 }

--- a/GPRS_Shield_Arduino.h
+++ b/GPRS_Shield_Arduino.h
@@ -357,6 +357,12 @@ public:
     int send(const char * str, int len);
 
     /** send data to socket without AT+CIPSEND=len
+     *  @param str string to be sent (from progmem)
+     *  @returns true if successful, false if a timeout occured
+     */
+    boolean send(const __FlashStringHelper* str);
+
+    /** send data to socket without AT+CIPSEND=len
      *  @param socket socket
      *  @param str string to be sent
      *  @returns true if successful

--- a/sim900.cpp
+++ b/sim900.cpp
@@ -92,7 +92,7 @@ void sim900_read_buffer(char *buffer, int count, unsigned int timeout, unsigned 
     }
 }
 
-uint16_t sim900_read_string_until(char *buffer, int count, char *pattern, unsigned int timeout, unsigned int chartimeout)
+uint16_t sim900_read_string_until(char *buffer, uint16_t count, char *pattern, unsigned int timeout, unsigned int chartimeout)
 {
     uint16_t i = 0;
     uint8_t sum = 0;

--- a/sim900.cpp
+++ b/sim900.cpp
@@ -97,7 +97,6 @@ uint16_t sim900_read_string_until(char *buffer, int count, char *pattern, unsign
     uint16_t i = 0;
     uint8_t sum = 0;
     uint8_t len = strlen(pattern);
-    bool is_timeout = false;
     unsigned long timerStart, prevChar;
     
     timerStart = millis();

--- a/sim900.h
+++ b/sim900.h
@@ -50,7 +50,7 @@ int   sim900_check_readable();
 int   sim900_wait_readable(int wait_time);
 void  sim900_flush_serial();
 void  sim900_read_buffer(char* buffer,int count,  unsigned int timeout = DEFAULT_TIMEOUT, unsigned int chartimeout = DEFAULT_INTERCHAR_TIMEOUT);
-uint16_t sim900_read_string_until(char *buffer, int count, char *pattern, unsigned int timeout = DEFAULT_TIMEOUT, unsigned int chartimeout = DEFAULT_INTERCHAR_TIMEOUT);																																										
+uint16_t sim900_read_string_until(char *buffer, uint16_t count, char *pattern, unsigned int timeout = DEFAULT_TIMEOUT, unsigned int chartimeout = DEFAULT_INTERCHAR_TIMEOUT);
 void  sim900_clean_buffer(char* buffer, int count);
 void  sim900_send_byte(uint8_t data);
 void  sim900_send_char(const char c);


### PR DESCRIPTION
I actually do not know how GPRS::is_connected was ever working. To me the manual is quite clear about it. I tested with SIM800L.