### PR TITLE
NULL initialization for GPRS object.

### DIFF
--- a/GPRS_Shield_Arduino.cpp
+++ b/GPRS_Shield_Arduino.cpp
@@ -32,7 +32,7 @@
 #include <stdio.h>
 #include "GPRS_Shield_Arduino.h"
 
-GPRS* GPRS::inst;
+GPRS* GPRS::inst = NULL;
 
 GPRS::GPRS(uint8_t tx, uint8_t rx, uint32_t baudRate):gprsSerial(tx,rx)
 {


### PR DESCRIPTION
There should be an initialization NULL for the Object as if you try to access it with any initialization, there could be a way to prevent the unexpected behavior, and if you implement the singleton pattern, it is a good practice to define the instance NULL.