### PR TITLE
Fix timeout to prevent sent SMS error.

### DIFF
--- a/GPRS_Shield_Arduino.cpp
+++ b/GPRS_Shield_Arduino.cpp
@@ -154,7 +154,7 @@ bool GPRS::sendSMS(const char *number, const char *data)
     sim900_send_cmd(data);
     delay(500);
     sim900_send_End_Mark();
-    return sim900_wait_for_resp("OK\r\n", CMD, 20);
+    return sim900_wait_for_resp("OK\r\n", CMD, 20U, 5000U);
 }
 
 char GPRS::isSMSunread()


### PR DESCRIPTION
I recently used your library to use my SIM900 shield.
Each time I send an SMS, it is received by the recipient but the *sendSMS* always returns FALSE.
I had to add an extra timeout and then the API returned TRUE.

Could maybe be useful to someone else.