### PR TITLE
added `CNMI` command to init function

### DIFF
--- a/GPRS_Shield_Arduino.cpp
+++ b/GPRS_Shield_Arduino.cpp
@@ -56,6 +56,11 @@ bool GPRS::init(void)
     }
     //delay(500);	It is not necessary, as we have time before next command
     
+    // set New Message Indicator
+    if(!sim900_check_with_cmd(F("AT+CNMI=1,1,0,0,0\r\n"), "OK\r\n", CMD)) { // Set message mode to ASCII
+        return false;
+    }
+	
     if(!checkSIMStatus()) {
 		return false;
     }


### PR DESCRIPTION
I had problems when using the `CMGL` command and it wouldn't reply with any message in the buffer, adding the CNMI configuration in the init solved the issue for me